### PR TITLE
FIXID S1073793: Hyperic plugin for VFWS can't autodiscover with SSL port

### DIFF
--- a/src/main/java/com/vmware/vfabric/hyperic/plugin/vfws/PWSServerDetector.java
+++ b/src/main/java/com/vmware/vfabric/hyperic/plugin/vfws/PWSServerDetector.java
@@ -41,7 +41,7 @@ import org.apache.commons.logging.LogFactory;
 public class PWSServerDetector
     extends DaemonDetector implements AutoServerDetector, FileServerDetector {
 
-    private static final String _logCtx = VfwsServerDetector.class.getName();
+    private static final String _logCtx = PWSServerDetector.class.getName();
     private final static Log _log = LogFactory.getLog(_logCtx);
 
     private static final String ARG_ROOTDIR = "-d";
@@ -57,7 +57,7 @@ public class PWSServerDetector
     private static final String HTTPD_CONF = "/conf/httpd.conf";
     private static final String CONF_DIRECTIVE_LISTEN = "LISTEN";
     private static final String CONF_DIRECTIVE_INCLUDE = "INCLUDE";
-    private static final String DEFAULT_WINDOWS_SERVICE_PREFIX = "Pivotalhttpd";
+    private static final String DEFAULT_WINDOWS_SERVICE_PREFIX = "httpd-WebServer";
     private static final String PROP_PROGRAM = "program";
     private static final String PROP_SERVICENAME = "service_name";
     private static final String PROP_PIDFILE = "pidfile";
@@ -146,8 +146,9 @@ public class PWSServerDetector
                     servers.add(server);
                 }
                 if (!success) {
-                    _log.error("[getServers] Found potential PWS process however was unable to determine URL of mod_bmx");
-                    _log.error("[getServers] Make sure -d is specified on command line and that proxying or redirecting isn't including /bmx");
+                	// this is not error.
+                    _log.debug("[getServers] Found potential PWS process however was unable to determine URL of mod_bmx");
+                    _log.debug("[getServers] Make sure -d is specified on command line and that proxying or redirecting isn't including /bmx");
                 }
             }
         }

--- a/src/main/java/com/vmware/vfabric/hyperic/plugin/vfws/VfwsServerDetector.java
+++ b/src/main/java/com/vmware/vfabric/hyperic/plugin/vfws/VfwsServerDetector.java
@@ -118,6 +118,10 @@ public class VfwsServerDetector
                     ServerResource server = createServerResource(installPath);
                     ConfigResponse cprop = new ConfigResponse();
                     String version = getVersion((String) serverStatus.get("ServerVersion"));
+                    if(version == null) {
+                    	// avoid java.lang.NullPointerException when PivotalWebServer 
+                    	continue;
+                    }
                     if (!version.equals(getTypeInfo().getVersion())) {
                         // Version not matched
                         continue;
@@ -143,8 +147,9 @@ public class VfwsServerDetector
                     servers.add(server);
                 }
                 if (!success) {
-                    _log.error("[getServers] Found potential VFWS process however was unable to determine URL of mod_bmx");
-                    _log.error("[getServers] Make sure -d is specified on command line and that proxying or redirecting isn't including /bmx");
+                	// may not be an error.
+                    _log.debug("[getServers] Found potential VFWS process however was unable to determine URL of mod_bmx");
+                    _log.debug("[getServers] Make sure -d is specified on command line and that proxying or redirecting isn't including /bmx");
                 }
             }
         }

--- a/src/main/resources/etc/hq-plugin.xml
+++ b/src/main/resources/etc/hq-plugin.xml
@@ -1,25 +1,7 @@
 <?xml version="1.0"?>
 
-<!--
-		Hyperic plugin for vFabric/Pivotal Web Server
-		Copyright (C) 2012-2015, Pivotal Software, Inc
-
-		This program is free software; you can redistribute it and/or modify
-		it under the terms of the GNU General Public License as published by
-		the Free Software Foundation; either version 2 of the License.
-
-		This program is distributed in the hope that it will be useful,
-		but WITHOUT ANY WARRANTY; without even the implied warranty of
-		MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-		GNU General Public License for more details.
-
-		You should have received a copy of the GNU General Public License along
-		with this program; if not, write to the Free Software Foundation, Inc.,
-		51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
--->
-
 <plugin package="com.vmware.vfabric.hyperic.plugin.vfws" name="vfws">
-	<property name="PLUGIN_VERSION" value="@project.version@" />
+	<property name="PLUGIN_VERSION" value="1.5" />
 
 	<classpath>
 		<include name="pdk/plugins/netservices-plugin.jar" />
@@ -214,6 +196,12 @@
 
 	</server>
 
+	<server name="vFabric Web Server" version="5.2" include="5.1">
+	</server>
+
+	<server name="vFabric Web Server" version="5.3" include="5.1">
+	</server>
+
 	<server name="Pivotal Web Server" version="5.4"
 		include="vFabric Web Server 5.1">
 		<plugin type="autoinventory" class="PWSServerDetector" />
@@ -222,16 +210,13 @@
 	<server name="Pivotal Web Server" version="5.5" include="5.4">
 	</server>
 
-	<server name="vFabric Web Server" version="5.2" include="5.1">
-	</server>
-
-	<server name="vFabric Web Server" version="5.3" include="5.1">
-	</server>
-
 	<server name="Pivotal Web Server" version="6.0" include="5.4">
 	</server>
 
 	<server name="Pivotal Web Server" version="6.1" include="6.0">
+	</server>
+
+	<server name="Pivotal Web Server" version="6.2" include="6.0">
 	</server>
 
 	<help name="vFabric Web Server 5.1">
@@ -253,9 +238,9 @@
     In addition by default mod_bmx_* modules are enabled in httpd.conf. 
     </p>
     <p>
-LoadModule bmx_module            "/opt/vmware/vfabric-web-server/httpd-2.2/modules/mod_bmx.so"<br/>
-LoadModule bmx_status_module     "/opt/vmware/vfabric-web-server/httpd-2.2/modules/mod_bmx_status.so"<br/>
-LoadModule bmx_vhost_module      "/opt/vmware/vfabric-web-server/httpd-2.2/modules/mod_bmx_vhost.so"<br/>
+LoadModule bmx_module            "/opt/vmware/vfabric-web-server/httpd-2.4/modules/mod_bmx.so"<br/>
+LoadModule bmx_status_module     "/opt/vmware/vfabric-web-server/httpd-2.4/modules/mod_bmx_status.so"<br/>
+LoadModule bmx_vhost_module      "/opt/vmware/vfabric-web-server/httpd-2.4/modules/mod_bmx_vhost.so"<br/>
     </p>
     ]]>
 	</help>
@@ -266,14 +251,6 @@ LoadModule bmx_vhost_module      "/opt/vmware/vfabric-web-server/httpd-2.2/modul
 	<help name="vFabric Web Server 5.3" include="vFabric Web Server 5.1">
 	</help>
 
-	<help name="Pivotal Web Server 5.5" include="Pivotal Web Server 5.4">
-	</help>
-
-	<help name="Pivotal Web Server 6.0" include="Pivotal Web Server 5.4">
-	</help>
-
-	<help name="Pivotal Web Server 6.1" include="Pivotal Web Server 6.0">
-	</help>
 
     <help name="Pivotal Web Server 5.4">
     <![CDATA[
@@ -294,11 +271,22 @@ LoadModule bmx_vhost_module      "/opt/vmware/vfabric-web-server/httpd-2.2/modul
     In addition by default mod_bmx_* modules are enabled in httpd.conf. 
     </p>
     <p>
-LoadModule bmx_module            "/opt/pivotal/webserver/httpd-2.2/modules/mod_bmx.so"<br/>
-LoadModule bmx_status_module     "/opt/pivotal/webserver/httpd-2.2/modules/mod_bmx_status.so"<br/>
-LoadModule bmx_vhost_module      "/opt/pivotal/webserver/httpd-2.2/modules/mod_bmx_vhost.so"<br/>
+LoadModule bmx_module            "/opt/pivotal/webserver/httpd-2.4/modules/mod_bmx.so"<br/>
+LoadModule bmx_status_module     "/opt/pivotal/webserver/httpd-2.4/modules/mod_bmx_status.so"<br/>
+LoadModule bmx_vhost_module      "/opt/pivotal/webserver/httpd-2.4/modules/mod_bmx_vhost.so"<br/>
     </p>
     ]]>
     </help>
 
+	<help name="Pivotal Web Server 5.5" include="Pivotal Web Server 5.4">
+	</help>
+
+	<help name="Pivotal Web Server 6.0" include="Pivotal Web Server 5.4">
+	</help>
+
+	<help name="Pivotal Web Server 6.1" include="Pivotal Web Server 6.0">
+	</help>
+	
+	<help name="Pivotal Web Server 6.2" include="Pivotal Web Server 6.0">
+	</help>
 </plugin>


### PR DESCRIPTION
When pivotal web server only listen on SSL port, and its certificate was signed to its hostname. (site certificate, CN=<hostname>) We must use its hostname to connect it on SSL port. If we use "localhost", we'll get an error by failure of certificate validation.
