### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ Follow these steps to start using the vFabric Web Server Monitoring Plugin for H
 1. If necessary, configure each vFabric Web Server instance that you want to monitor with vFabric Hyperic.
 In particular, ensure that the BMX module is enabled in each instance.   Note that, in version 5.1 and 5.2(but not newer), all
 new vFabric Web Server instances are configured with BMX by default, so you may not need to perform any action
-for this step. See [Configure BMX for Monitoring vFabric Web Server Instances](http://pubs.vmware.com/vfabric52/index.jsp?topic=/com.vmware.vfabric.web-server.5.2/web-server/config-mod-bmx.html).
+for this step. See [Configure BMX for Monitoring vFabric Web Server Instances](https://pubs.vmware.com/vfabric52/index.jsp?topic=/com.vmware.vfabric.web-server.5.2/web-server/config-mod-bmx.html).
 
 2. Download the [Pivotal Web Server Monitoring Plugin JAR file](http://public.pivotal.com.s3.amazonaws.com/releases/plugins/ws-hq-plugin/com/vmware/vfabric/hyperic/plugin/vfws-plugin/1.5.RELEASE/vfws-plugin.jar).
 
 3. Upload the "vfws-plugin.jar" file to the Hyperic Server using the Hyperic Plugin Manager.  See
-[Plugin Manager](http://pubs.vmware.com/vfabricHyperic50/index.jsp?topic=/com.vmware.vfabric.hyperic.5.0/ui-Administration.Plugin.Manager.html).
+[Plugin Manager](https://pubs.vmware.com/vfabricHyperic50/index.jsp?topic=/com.vmware.vfabric.hyperic.5.0/ui-Administration.Plugin.Manager.html).
 
 License
 =======


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://public.pivotal.com.s3.amazonaws.com/releases/plugins/ws-hq-plugin/com/vmware/vfabric/hyperic/plugin/vfws-plugin/1.5.RELEASE/vfws-plugin.jar (404) with 1 occurrences could not be migrated:  
   ([https](https://public.pivotal.com.s3.amazonaws.com/releases/plugins/ws-hq-plugin/com/vmware/vfabric/hyperic/plugin/vfws-plugin/1.5.RELEASE/vfws-plugin.jar) result SSLHandshakeException).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://pubs.vmware.com/vfabricHyperic50/index.jsp?topic=/com.vmware.vfabric.hyperic.5.0/ui-Administration.Plugin.Manager.html with 1 occurrences migrated to:  
  https://pubs.vmware.com/vfabricHyperic50/index.jsp?topic=/com.vmware.vfabric.hyperic.5.0/ui-Administration.Plugin.Manager.html ([https](https://pubs.vmware.com/vfabricHyperic50/index.jsp?topic=/com.vmware.vfabric.hyperic.5.0/ui-Administration.Plugin.Manager.html) result 200).
* http://pubs.vmware.com/vfabric52/index.jsp?topic=/com.vmware.vfabric.web-server.5.2/web-server/config-mod-bmx.html with 1 occurrences migrated to:  
  https://pubs.vmware.com/vfabric52/index.jsp?topic=/com.vmware.vfabric.web-server.5.2/web-server/config-mod-bmx.html ([https](https://pubs.vmware.com/vfabric52/index.jsp?topic=/com.vmware.vfabric.web-server.5.2/web-server/config-mod-bmx.html) result 301).